### PR TITLE
Add type and array values validators

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -8,7 +8,7 @@ validate.validators.ref = function(value, options, key, attributes) {
   }
 }
 
-validate.validators.arrayValidator = function(values, options) {
+validate.validators.values = function(values, options) {
   if (!values.map) return
   const result = values.map(value => validate.single(value, options) || [])
   return [].concat(...result)

--- a/src/validate.js
+++ b/src/validate.js
@@ -8,6 +8,28 @@ validate.validators.ref = function(value, options, key, attributes) {
   }
 }
 
+validate.validators.arrayValidator = function(values, options) {
+  if (!values.map) return
+  const result = values.map(value => validate.single(value, options) || [])
+  return [].concat(...result)
+}
+
+validate.validators.type = function(value, type) {
+  if (!validate.isDefined(value)) return
+
+  const types = {
+    array: validate.isArray,
+    string: validate.isString,
+    boolean: validate.isBoolean,
+    number: validate.isNumber,
+    object: validate.isObject,
+  }
+
+  if (types[type] && !types[type](value)) {
+    return `value must be of type ${type}`
+  }
+}
+
 validate.extend(validate.validators.datetime, {
   parse: value => moment(value, moment.iso8601, true).utc().toDate(),
   format: (value, options) =>  moment.utc(value).format(options.dateOnly ? 'YYYY-MM-DD' : moment.iso8601)


### PR DESCRIPTION
```js
const constraints = {
  foo: {
    type: 'array',
    values: {
      type: 'string',
    },
  },
}

validate({ foo: ['bar', false] }, constraints)
// { foo: ['foo values must be of type string'] }
```