### PR TITLE
Add in/nin filters

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -2,7 +2,14 @@ const convertStringToBoolean = value => (
   typeof value === 'undefined' || ['0', 'false'].includes(value) ? false : true
 )
 
-const eq = (ctx, queryKey, dbKey = queryKey, transform = v => v) => {
+const createTransform = (ctx, queryKey) => {
+  if (Array.isArray(ctx.query[queryKey])) {
+    return v => ({ $in: v })
+  }
+  return v => v
+}
+
+const eq = (ctx, queryKey, dbKey = queryKey, transform = createTransform(ctx, queryKey)) => {
   if (typeof ctx.query[queryKey] !== 'undefined') {
     return {
       [dbKey]: transform(ctx.query[queryKey])
@@ -12,7 +19,7 @@ const eq = (ctx, queryKey, dbKey = queryKey, transform = v => v) => {
 }
 
 const ne = (ctx, queryKey, dbKey = queryKey, transform = v => v) => (
-  eq(ctx, queryKey, dbKey, v => ({ "$ne": transform(v) }))
+  eq(ctx, queryKey, dbKey, v => ({ $ne: transform(v) }))
 )
 
 const bool = (ctx, queryKey, dbKey = queryKey, transform = v => v) => (

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,20 +1,25 @@
+const { toArray } = require('./utils')
+
 const convertStringToBoolean = value =>
   typeof value === 'undefined' || ['0', 'false'].includes(value) ? false : true
 
 const eq = (ctx, queryKey, dbKey = queryKey, transform = v => v) => {
-  const value = ctx.query[queryKey]
-  if (typeof value !== 'undefined') {
+  if (typeof ctx.query[queryKey] !== 'undefined') {
     return {
-      [dbKey]: Array.isArray(value)
-        ? { $in: transform(value) }
-        : transform(value),
+      [dbKey]: transform(ctx.query[queryKey]),
     }
   }
   return {}
 }
 
+const $in = (ctx, queryKey, dbKey = queryKey, transform = v => v) =>
+  eq(ctx, queryKey, dbKey, v => ({ $in: transform(toArray(v)) }))
+
 const ne = (ctx, queryKey, dbKey = queryKey, transform = v => v) =>
   eq(ctx, queryKey, dbKey, v => ({ $ne: transform(v) }))
+
+const nin = (ctx, queryKey, dbKey = queryKey, transform = v => v) =>
+  eq(ctx, queryKey, dbKey, v => ({ $nin: transform(toArray(v)) }))
 
 const bool = (ctx, queryKey, dbKey = queryKey, transform = v => v) =>
   eq(ctx, queryKey, dbKey, v => transform(convertStringToBoolean(v)))
@@ -36,7 +41,9 @@ const published = ctx =>
 
 module.exports = {
   eq,
+  in: $in,
   ne,
+  nin,
   bool,
   regExp,
   published,

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,45 +1,38 @@
-const convertStringToBoolean = value => (
+const convertStringToBoolean = value =>
   typeof value === 'undefined' || ['0', 'false'].includes(value) ? false : true
-)
 
-const createTransform = (ctx, queryKey) => {
-  if (Array.isArray(ctx.query[queryKey])) {
-    return v => ({ $in: v })
-  }
-  return v => v
-}
-
-const eq = (ctx, queryKey, dbKey = queryKey, transform = createTransform(ctx, queryKey)) => {
-  if (typeof ctx.query[queryKey] !== 'undefined') {
+const eq = (ctx, queryKey, dbKey = queryKey, transform = v => v) => {
+  const value = ctx.query[queryKey]
+  if (typeof value !== 'undefined') {
     return {
-      [dbKey]: transform(ctx.query[queryKey])
+      [dbKey]: Array.isArray(value)
+        ? { $in: transform(value) }
+        : transform(value),
     }
   }
   return {}
 }
 
-const ne = (ctx, queryKey, dbKey = queryKey, transform = v => v) => (
+const ne = (ctx, queryKey, dbKey = queryKey, transform = v => v) =>
   eq(ctx, queryKey, dbKey, v => ({ $ne: transform(v) }))
-)
 
-const bool = (ctx, queryKey, dbKey = queryKey, transform = v => v) => (
+const bool = (ctx, queryKey, dbKey = queryKey, transform = v => v) =>
   eq(ctx, queryKey, dbKey, v => transform(convertStringToBoolean(v)))
-)
 
-const regExp = (ctx, queryKey, dbKey = queryKey, modifiers = 'i') => (
+const regExp = (ctx, queryKey, dbKey = queryKey, modifiers = 'i') =>
   eq(ctx, queryKey, dbKey, value => new RegExp(value, modifiers))
-)
 
 /**
  * @apiDefine PublishedFilter
  * @apiParam {Boolean} [published] Published filter e.g. /?published=true
  */
-const published = ctx => eq(ctx, 'published', 'publishedAt', v => {
-  if (convertStringToBoolean(v)) {
-    return { $ne: null }
-  }
-  return null
-})
+const published = ctx =>
+  eq(ctx, 'published', 'publishedAt', v => {
+    if (convertStringToBoolean(v)) {
+      return { $ne: null }
+    }
+    return null
+  })
 
 module.exports = {
   eq,

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,8 @@ const randomInt = (max = 100) => Math.floor(Math.random() * Math.floor(max))
 
 const sample = arr => arr[randomInt(arr.length - 1)]
 
+const toArray = value => [].concat(typeof value === 'undefined' ? [] : value)
+
 module.exports = {
   nullify,
   nullOrDateString,
@@ -34,4 +36,5 @@ module.exports = {
   times,
   randomInt,
   sample,
+  toArray,
 }

--- a/test/filtersTest.js
+++ b/test/filtersTest.js
@@ -26,25 +26,31 @@ describe('filters', () => {
       const query = eq(ctx, 'foo')
       expect(query).to.eql({})
     })
+
+    it('handles array', function() {
+      const ctx = { query: { foo: ['bar', 'baz'] } }
+      const query = eq(ctx, 'foo', 'foo')
+      expect(query).to.eql({ foo: { $in: ['bar', 'baz'] } })
+    })
   })
 
   describe('ne', () => {
     it('returns fulfilled query', function() {
       const ctx = { query: { foo: 'bar' } }
       const query = ne(ctx, 'foo')
-      expect(query).to.eql({ foo: { '$ne':  'bar' }})
+      expect(query).to.eql({ foo: { $ne: 'bar' } })
     })
 
     it('returns fulfilled query with db key', function() {
       const ctx = { query: { foo: 'bar' } }
       const query = ne(ctx, 'foo', 'bar')
-      expect(query).to.eql({ bar: { '$ne':  'bar' } })
+      expect(query).to.eql({ bar: { $ne: 'bar' } })
     })
 
     it('returns fulfilled query with transform', function() {
       const ctx = { query: { foo: 'bar' } }
       const query = ne(ctx, 'foo', 'foo', v => `${v}!!`)
-      expect(query).to.eql({ foo: { '$ne':  'bar!!' }})
+      expect(query).to.eql({ foo: { $ne: 'bar!!' } })
     })
 
     it('returns empty object when ctx.query has no query key', function() {

--- a/test/filtersTest.js
+++ b/test/filtersTest.js
@@ -1,61 +1,119 @@
 const { expect } = require('chai')
-const { eq, ne, bool, regExp, published } = require('../src/filters')
+const filters = require('../src/filters')
 
 describe('filters', () => {
   describe('eq', () => {
     it('returns fulfilled query', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = eq(ctx, 'foo')
+      const query = filters.eq(ctx, 'foo')
       expect(query).to.eql({ foo: 'bar' })
     })
 
     it('returns fulfilled query with db key', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = eq(ctx, 'foo', 'bar')
+      const query = filters.eq(ctx, 'foo', 'bar')
       expect(query).to.eql({ bar: 'bar' })
     })
 
     it('returns fulfilled query with transform', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = eq(ctx, 'foo', 'foo', v => `${v}!!`)
+      const query = filters.eq(ctx, 'foo', 'foo', v => `${v}!!`)
       expect(query).to.eql({ foo: 'bar!!' })
     })
 
     it('returns empty object when ctx.query has no query key', function() {
       const ctx = { query: {} }
-      const query = eq(ctx, 'foo')
+      const query = filters.eq(ctx, 'foo')
       expect(query).to.eql({})
     })
+  })
 
-    it('handles array', function() {
+  describe('in', () => {
+    it('returns fulfilled query', function() {
       const ctx = { query: { foo: ['bar', 'baz'] } }
-      const query = eq(ctx, 'foo', 'foo')
+      const query = filters.in(ctx, 'foo')
       expect(query).to.eql({ foo: { $in: ['bar', 'baz'] } })
+    })
+
+    it('returns fulfilled query with db key', function() {
+      const ctx = { query: { foo: ['bar', 'baz'] } }
+      const query = filters.in(ctx, 'foo', 'bar')
+      expect(query).to.eql({ bar: { $in: ['bar', 'baz'] } })
+    })
+
+    it('returns fulfilled query with transform', function() {
+      const ctx = { query: { foo: ['bar', 'baz'] } }
+      const query = filters.in(ctx, 'foo', 'foo', v => v.map(x => `${x}!!`))
+      expect(query).to.eql({ foo: { $in: ['bar!!', 'baz!!'] } })
+    })
+
+    it('transforms into array', function() {
+      const ctx = { query: { foo: 'bar' } }
+      const query = filters.in(ctx, 'foo')
+      expect(query).to.eql({ foo: { $in: ['bar'] } })
+    })
+
+    it('returns empty object when ctx.query has no query key', function() {
+      const ctx = { query: {} }
+      const query = filters.in(ctx, 'foo')
+      expect(query).to.eql({})
     })
   })
 
   describe('ne', () => {
     it('returns fulfilled query', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = ne(ctx, 'foo')
+      const query = filters.ne(ctx, 'foo')
       expect(query).to.eql({ foo: { $ne: 'bar' } })
     })
 
     it('returns fulfilled query with db key', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = ne(ctx, 'foo', 'bar')
+      const query = filters.ne(ctx, 'foo', 'bar')
       expect(query).to.eql({ bar: { $ne: 'bar' } })
     })
 
     it('returns fulfilled query with transform', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = ne(ctx, 'foo', 'foo', v => `${v}!!`)
+      const query = filters.ne(ctx, 'foo', 'foo', v => `${v}!!`)
       expect(query).to.eql({ foo: { $ne: 'bar!!' } })
     })
 
     it('returns empty object when ctx.query has no query key', function() {
       const ctx = { query: {} }
-      const query = ne(ctx, 'foo')
+      const query = filters.ne(ctx, 'foo')
+      expect(query).to.eql({})
+    })
+  })
+
+  describe('nin', () => {
+    it('returns fulfilled query', function() {
+      const ctx = { query: { foo: ['bar', 'baz'] } }
+      const query = filters.nin(ctx, 'foo')
+      expect(query).to.eql({ foo: { $nin: ['bar', 'baz'] } })
+    })
+
+    it('returns fulfilled query with db key', function() {
+      const ctx = { query: { foo: ['bar', 'baz'] } }
+      const query = filters.nin(ctx, 'foo', 'bar')
+      expect(query).to.eql({ bar: { $nin: ['bar', 'baz'] } })
+    })
+
+    it('returns fulfilled query with transform', function() {
+      const ctx = { query: { foo: ['bar', 'baz'] } }
+      const query = filters.nin(ctx, 'foo', 'foo', v => v.map(x => `${x}!!`))
+      expect(query).to.eql({ foo: { $nin: ['bar!!', 'baz!!'] } })
+    })
+
+    it('transforms into array', function() {
+      const ctx = { query: { foo: 'bar' } }
+      const query = filters.nin(ctx, 'foo')
+      expect(query).to.eql({ foo: { $nin: ['bar'] } })
+    })
+
+    it('returns empty object when ctx.query has no query key', function() {
+      const ctx = { query: {} }
+      const query = filters.nin(ctx, 'foo')
       expect(query).to.eql({})
     })
   })
@@ -63,31 +121,31 @@ describe('filters', () => {
   describe('bool', () => {
     it('returns fulfilled query with true', function() {
       const ctx = { query: { foo: 'true' } }
-      const query = bool(ctx, 'foo')
+      const query = filters.bool(ctx, 'foo')
       expect(query).to.eql({ foo: true })
     })
 
     it('returns fulfilled query with false', function() {
       const ctx = { query: { foo: 'false' } }
-      const query = bool(ctx, 'foo')
+      const query = filters.bool(ctx, 'foo')
       expect(query).to.eql({ foo: false })
     })
 
     it('returns fulfilled query with db key', function() {
       const ctx = { query: { foo: 'true' } }
-      const query = bool(ctx, 'foo', 'bar')
+      const query = filters.bool(ctx, 'foo', 'bar')
       expect(query).to.eql({ bar: true })
     })
 
     it('returns fulfilled query with transform', function() {
       const ctx = { query: { foo: 'true' } }
-      const query = bool(ctx, 'foo', 'foo', v => !v)
+      const query = filters.bool(ctx, 'foo', 'foo', v => !v)
       expect(query).to.eql({ foo: false })
     })
 
     it('returns empty object when ctx.query has no query key', function() {
       const ctx = { query: {} }
-      const query = bool(ctx, 'foo')
+      const query = filters.bool(ctx, 'foo')
       expect(query).to.eql({})
     })
   })
@@ -95,25 +153,25 @@ describe('filters', () => {
   describe('regExp', () => {
     it('returns fulfilled query', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = regExp(ctx, 'foo')
+      const query = filters.regExp(ctx, 'foo')
       expect(query).to.eql({ foo: /bar/i })
     })
 
     it('returns fulfilled query with db key', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = regExp(ctx, 'foo', 'bar')
+      const query = filters.regExp(ctx, 'foo', 'bar')
       expect(query).to.eql({ bar: /bar/i })
     })
 
     it('returns fulfilled query with modifiers', function() {
       const ctx = { query: { foo: 'bar' } }
-      const query = regExp(ctx, 'foo', 'foo', 'g')
+      const query = filters.regExp(ctx, 'foo', 'foo', 'g')
       expect(query).to.eql({ foo: /bar/g })
     })
 
     it('returns empty object when ctx.query has no query key', function() {
       const ctx = { query: {} }
-      const query = regExp(ctx, 'foo')
+      const query = filters.regExp(ctx, 'foo')
       expect(query).to.eql({})
     })
   })
@@ -121,19 +179,19 @@ describe('filters', () => {
   describe('published', () => {
     it('returns true query', function() {
       const ctx = { query: { published: 'true' } }
-      const query = published(ctx)
+      const query = filters.published(ctx)
       expect(query).to.eql({ publishedAt: { $ne: null } })
     })
 
     it('returns false query', function() {
       const ctx = { query: { published: 'false' } }
-      const query = published(ctx)
+      const query = filters.published(ctx)
       expect(query).to.eql({ publishedAt: null })
     })
 
     it('returns empty object when ctx.query has no published key', function() {
       const ctx = { query: {} }
-      const query = published(ctx)
+      const query = filters.published(ctx)
       expect(query).to.eql({})
     })
   })


### PR DESCRIPTION
Handles queries like `/?name=Foo&name=Bar`, which will be resolved to `{ name: ['Foo', 'Bar'] }` in `ctx.query`.