### PR TITLE
Uses prepublishOnly instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "patch": "npm version patch && npm publish --access public",
     "minor": "npm version minor && npm publish --access public",
     "major": "npm version major && npm publish --access public",
-    "prepublish": "ENV=test npm test",
+    "prepublishOnly": "ENV=test npm test",
     "postpublish": "git push origin master --follow-tags"
   },
   "dependencies": {


### PR DESCRIPTION
npm prepublish runs on local npm installs too, which is not necessary for @hellomd/node-sdk. prepublishOnly would fit best, since it runs only before publishing the package in the npm registry.

See https://docs.npmjs.com/misc/scripts