### PR TITLE
improve debug log to show nested objects

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,3 +1,4 @@
+const util = require('util')
 const { axios } = require('./axios')
 
 const serviceTokenHeader = (ctx, args) => ({
@@ -56,7 +57,10 @@ const buildEndpoint = ctx => def => {
         })
         return transform(results)
       } catch (err) {
-        debug && console.log(err.response)
+        debug && console.log(util.inspect(err.response, {
+          depth: 4,
+          colors: true,
+        }))
         const resCode = err.response ? err.response.status : 500
         if (resCode < 500 || i === maxRetries) {
           const errObj = errors[resCode.toString()]


### PR DESCRIPTION
This makes it easier to debug.

Compare:
Before:
![image](https://user-images.githubusercontent.com/1041647/44603412-0e916c80-a7b9-11e8-98a5-e118166bcf7b.png)
After:
![image](https://user-images.githubusercontent.com/1041647/44603433-1e10b580-a7b9-11e8-9d14-b5d0f4a21c6a.png)
