### PR TITLE
general improvements to validation rules and fix issue on values validator

### DIFF
--- a/test/validateTest.js
+++ b/test/validateTest.js
@@ -1,18 +1,26 @@
 const { expect } = require('chai')
 const { plainValidate } = require('../src/validate')
 
-const expectError = result =>
+const expectError = (result, length = 1) =>
   expect(result)
     .to.have.property('foo')
     .that.is.an('array')
-    .with.lengthOf(1)
+    .with.lengthOf(length)
 
 describe('plainValidate', () => {
   describe('values', () => {
     it('passes', () => {
       const constraints = { foo: { values: { presence: true } } }
-      const result = plainValidate({ foo: true }, constraints)
+      const result = plainValidate({ foo: [] }, constraints)
       expect(result).to.be.undefined
+    })
+
+    it('fails with no array', () => {
+      const constraints = {
+        foo: { values: { presence: { allowEmpty: false } } },
+      }
+      const result = plainValidate({ foo: true }, constraints)
+      expectError(result)
     })
 
     it('fails', () => {
@@ -31,21 +39,92 @@ describe('plainValidate', () => {
       expectError(result)
     })
 
-    it('passes with object', () => {
-      const constraints = { foo: { values: { bar: { presence: true } } } }
-      const result = plainValidate({ foo: [{ bar: 'baz' }] }, constraints)
-      expect(result).to.be.undefined
-    })
-
     it('pass with value null', () => {
       const constraints = { foo: { values: { type: 'number' } } }
       const result = plainValidate({ foo: [null] }, constraints)
       expect(result).to.be.undefined
     })
 
-    it('fails with object', () => {
+    it('pass with custom constraints using function', () => {
+      const customConstraints = {
+        first: { type: 'number' },
+        _: { type: 'string' },
+      }
+
+      const constraints = {
+        foo: {
+          values: {
+            constraints: (value, index) =>
+              index === 0 ? customConstraints.first : customConstraints._,
+          },
+        },
+      }
+
+      const result = plainValidate({ foo: [1, 'a', 'b'] }, constraints)
+      expect(result).to.be.undefined
+    })
+
+    it('[deprecated] fails with object', () => {
       const constraints = { foo: { values: { bar: { presence: true } } } }
       const result = plainValidate({ foo: [{}] }, constraints)
+      expectError(result)
+    })
+
+    it('[deprecated] passes with object', () => {
+      const constraints = { foo: { values: { bar: { presence: true } } } }
+      const result = plainValidate({ foo: [{ bar: 'baz' }] }, constraints)
+      expect(result).to.be.undefined
+    })
+
+    // above are deprecated because of this bug:
+    // it('[deprecated] does not work', () => {
+    //   const constraints = { foo: { values: { bar: { presence: true } } } }
+    //   const result = plainValidate({ foo: [null, { bar: 'baz' }] }, constraints)
+    //   // throws an error
+    // })
+
+    it('pass with object', () => {
+      const constraints = {
+        foo: {
+          values: {
+            isArrayOfObjects: true,
+            constraints: {
+              a: { type: 'number', presence: { allowEmpty: false } },
+            },
+          },
+        },
+      }
+      const result = plainValidate({ foo: [{ a: 1 }, { a: 2 }] }, constraints)
+      expect(result).to.be.undefined
+    })
+
+    it('fails with object with null value and missing key', () => {
+      const constraints = {
+        foo: {
+          values: {
+            isArrayOfObjects: true,
+            constraints: {
+              a: { type: 'number', presence: { allowEmpty: false } },
+            },
+          },
+        },
+      }
+      const result = plainValidate({ foo: [null, {}] }, constraints)
+
+      expectError(result, 2)
+    })
+
+    it('fails with object with null value', () => {
+      const constraints = {
+        foo: {
+          values: {
+            isArrayOfObjects: true,
+            constraints: { a: { type: 'number' } },
+          },
+        },
+      }
+      const result = plainValidate({ foo: [null, {}] }, constraints)
+
       expectError(result)
     })
   })
@@ -72,6 +151,101 @@ describe('plainValidate', () => {
         constraints,
       )
       expect(result).to.be.undefined
+    })
+  })
+
+  describe('ref', () => {
+    it('passes', () => {
+      const constraints = {
+        foo: {
+          ref: true,
+        },
+      }
+      const result = plainValidate(
+        { foo: 'a:5bed8593176c0fc8caf0d0b2' },
+        constraints,
+      )
+      expect(result).to.be.undefined
+    })
+
+    it('fails with missing resource kind', () => {
+      const constraints = {
+        foo: {
+          ref: true,
+        },
+      }
+      const result = plainValidate(
+        { foo: '  :5bed8593176c0fc8caf0d0b2' },
+        constraints,
+      )
+      expectError(result)
+    })
+
+    it('fails with missing resource id', () => {
+      const constraints = {
+        foo: {
+          ref: true,
+        },
+      }
+      const result = plainValidate({ foo: 'abc:  ' }, constraints)
+
+      expectError(result)
+    })
+
+    it('fails with non ref string', () => {
+      const constraints = {
+        foo: {
+          ref: true,
+        },
+      }
+      const result = plainValidate({ foo: 'abcdefg' }, constraints)
+
+      expectError(result)
+    })
+
+    it('fails with non objectid resource id because of default id constraint', () => {
+      const constraints = {
+        foo: {
+          ref: true,
+        },
+      }
+      const result = plainValidate({ foo: 'abc:abcdefg' }, constraints)
+
+      expectError(result)
+    })
+
+    it('fails with custom resource id constraint', () => {
+      const constraints = {
+        foo: {
+          ref: {
+            resourceIdConstraint: {
+              length: { is: 2 },
+            },
+          },
+        },
+      }
+      const result = plainValidate(
+        { foo: 'abc:5bed8593176c0fc8caf0d0b2' },
+        constraints,
+      )
+      expectError(result)
+    })
+
+    it('fails with custom resource kind constraint', () => {
+      const constraints = {
+        foo: {
+          ref: {
+            resourceKindConstraint: {
+              inclusion: ['a', 'b', 'c'],
+            },
+          },
+        },
+      }
+      const result = plainValidate(
+        { foo: 'd:5bed8593176c0fc8caf0d0b2' },
+        constraints,
+      )
+      expectError(result)
     })
   })
 


### PR DESCRIPTION
- `ref`: can now specify separated constraints for resource kind and resource id, a default one was added for resource id, to make sure it's a valid `ObjectId`
- `values`:
    - fixed error when validating array of objects which had non object values
    - added `constraints` and `isArrayOfObjects` options, which should be used when validating objects,
        if no `constraints` option is given, it assumes the old behavior, for backward compatibility.
    - `valuesFn` deprecated since the `values` validator has the same functionality now, by passing a function as the `constraint` option

Other validators were improved by allowing to pass custom error messages