### PR TITLE
add postgis spatial_ref_sys table to skipped tables on db databaseCleaner

### DIFF
--- a/src/jestUtils/databaseCleaner.js
+++ b/src/jestUtils/databaseCleaner.js
@@ -3,7 +3,11 @@ const postgres = async (knex, config = {}) => {
   const {
     schema = 'public',
     strategy = 'truncation',
-    skipTables = ['migrations'],
+    skipTables = [
+      'migrations',
+      // postgis tables
+      'spatial_ref_sys',
+    ],
   } = config
 
   if (strategy !== 'deletion' && strategy !== 'truncation') {


### PR DESCRIPTION
This is needed to avoid the following error when using postgis fns:
```
 GetProj4StringSPI: Cannot find SRID (4326) in spatial_ref_sys
```